### PR TITLE
Currency Conversion Use Case

### DIFF
--- a/src/main/java/app/LoggedInUseCaseFactory.java
+++ b/src/main/java/app/LoggedInUseCaseFactory.java
@@ -1,12 +1,19 @@
 package app;
 
+import data_access.ExchangeRateClient;
 import interface_adapter.logged_in.LoggedInViewModel;
 import interface_adapter.logged_in.add_stock.AddStockController;
 import interface_adapter.logged_in.add_stock.AddStockPresenter;
+import interface_adapter.logged_in.currency_conversion.CurrencyController;
+import interface_adapter.logged_in.currency_conversion.CurrencyPresenter;
 import use_case.add_stock.AddStockInputBoundary;
 import use_case.add_stock.AddStockInteractor;
 import use_case.add_stock.AddStockOutputBoundary;
 import use_case.add_stock.StockCalculationService;
+import use_case.currency_conversion.CurrencyDataAccessInterface;
+import use_case.currency_conversion.CurrencyInputBoundary;
+import use_case.currency_conversion.CurrencyInteractor;
+import use_case.currency_conversion.CurrencyOutputBoundary;
 import use_case.show.StockPriceDataAccessInterface;
 import use_case.signup.PortfolioDataAccessInterface;
 import view.LoggedInView;
@@ -18,14 +25,12 @@ import interface_adapter.delete_user.DeletePresenter;
 import interface_adapter.delete_user.DeleteState;
 import interface_adapter.delete_user.DeleteViewModel;
 import interface_adapter.editStock.EditStockController;
-import interface_adapter.logged_in.LoggedInViewModel;
 import interface_adapter.login.LoginViewModel;
 import interface_adapter.logged_in.show.ShowController;
 import interface_adapter.logged_in.show.ShowPresenter;
 import use_case.delete_user.DeleteInputBoundary;
 import use_case.delete_user.DeleteInteractor;
 import use_case.delete_user.DeleteOutputBoundary;
-import use_case.delete_user.DeleteUserDataAccessInterface;
 import use_case.editStock.EditStockInputBoundary;
 import use_case.editStock.EditStockOutputBoundary;
 import use_case.editStock.EditStockUserDataAccessInterface;
@@ -39,8 +44,6 @@ import use_case.logout.LogoutInteractor;
 import use_case.logout.LogoutOutputBoundary;
 import use_case.signup.SignupUserDataAccessInterface;
 import view.LoginView;
-import view.ViewManager;
-import view.validation.StockFieldValidator;
 import view.validation.StockFieldValidatorImpl;
 
 import javax.swing.*;
@@ -72,11 +75,19 @@ public class LoggedInUseCaseFactory {
             EditStockController editStockController = createEditStockController(viewManagerModel, loggedInViewModel, editStockUserDataAccessInterface, portfolioDataAccessObject);
 
             LogoutController logoutController = createLogoutController(loginViewModel, loggedInViewModel, viewManagerModel);
-            return new LoggedInView(appFrame, loggedInViewModel, deleteState, deleteController, loginView, stockFieldValidator, addStockController, logoutController, showController, editStockController);
+            CurrencyController currencyController = createCurrentyController(loggedInViewModel);
+            return new LoggedInView(appFrame, loggedInViewModel, deleteState, deleteController, loginView, stockFieldValidator, addStockController, logoutController, showController, editStockController, currencyController);
         }catch(IOException e){
             JOptionPane.showMessageDialog(null, "Could not open user data file");
         }
         return null;
+    }
+
+    private static CurrencyController createCurrentyController(LoggedInViewModel loggedInViewModel) {
+        CurrencyOutputBoundary currencyPresenter = new CurrencyPresenter(loggedInViewModel);
+        CurrencyDataAccessInterface currencyClient = new ExchangeRateClient();
+        CurrencyInputBoundary currencyInteractor = new CurrencyInteractor(currencyClient, currencyPresenter);
+        return new CurrencyController(currencyInteractor);
     }
 
     private static LogoutController createLogoutController(LoginViewModel loginViewModel, LoggedInViewModel loggedInViewModel, ViewManagerModel viewManagerModel) {

--- a/src/main/java/data_access/ExchangeRateClient.java
+++ b/src/main/java/data_access/ExchangeRateClient.java
@@ -18,7 +18,7 @@ public class ExchangeRateClient implements CurrencyDataAccessInterface {
 
     /**
      * Returns a JSONObject that contains the exchange rate data from
-     * ExchnageRate-API (https://www.exchangerate-api.com/docs/pair-conversion-requests).
+     * ExchangeRate-API (https://www.exchangerate-api.com/docs/pair-conversion-requests).
      *
      * @param base the three-letter currency code of your preferred base currency.
      * @param symbol = the three-letter currency code of the currency you want to convert to.

--- a/src/main/java/data_access/ExchangeRateClient.java
+++ b/src/main/java/data_access/ExchangeRateClient.java
@@ -1,0 +1,47 @@
+package data_access;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.json.JSONException;
+import org.json.JSONObject;
+import use_case.currency_conversion.CurrencyDataAccessInterface;
+
+import java.io.IOException;
+
+
+public class ExchangeRateClient implements CurrencyDataAccessInterface {
+
+    private static final String BASE_URL = "https://api.exchangeratesapi.io/v1/latest";
+
+    // Note: API key needs to be stored as environment variable in IDE; set this up locally
+
+    /**
+     * Returns a JSONObject that contains the Latest Rates Endpoint exchange rate data from
+     * the Exchange Rates API (https://exchangeratesapi.io/documentation/).
+     *
+     * @param base the three-letter currency code of your preferred base currency.
+     * @param symbol = the three-letter currency code of the currency you want to convert to.
+     */
+
+    @Override
+    public JSONObject getCurrencyInfo(String base, String symbol) {
+        OkHttpClient client = new OkHttpClient().newBuilder().build();
+        Request request = new Request.Builder()
+                .url(String.format(BASE_URL + "?access_key=%s&base=%s&symbols=%s",
+                        System.getenv("CURRENCY_API_KEY"), base, symbol))
+                .build();
+
+        try {
+            Response response = client.newCall(request).execute();
+            JSONObject responseBody = new JSONObject(response.body().string());
+
+            System.out.println("HTTP Status: " + response.code());
+            System.out.println("JSON Response String: " + responseBody);
+
+            return responseBody;
+        } catch (IOException | JSONException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/data_access/ExchangeRateClient.java
+++ b/src/main/java/data_access/ExchangeRateClient.java
@@ -12,13 +12,13 @@ import java.io.IOException;
 
 public class ExchangeRateClient implements CurrencyDataAccessInterface {
 
-    private static final String BASE_URL = "https://api.exchangeratesapi.io/v1/latest";
+    private static final String BASE_URL = "https://v6.exchangerate-api.com/v6/";
 
     // Note: API key needs to be stored as environment variable in IDE; set this up locally
 
     /**
-     * Returns a JSONObject that contains the Latest Rates Endpoint exchange rate data from
-     * the Exchange Rates API (https://exchangeratesapi.io/documentation/).
+     * Returns a JSONObject that contains the exchange rate data from
+     * ExchnageRate-API (https://www.exchangerate-api.com/docs/pair-conversion-requests).
      *
      * @param base the three-letter currency code of your preferred base currency.
      * @param symbol = the three-letter currency code of the currency you want to convert to.
@@ -28,7 +28,7 @@ public class ExchangeRateClient implements CurrencyDataAccessInterface {
     public JSONObject getCurrencyInfo(String base, String symbol) {
         OkHttpClient client = new OkHttpClient().newBuilder().build();
         Request request = new Request.Builder()
-                .url(String.format(BASE_URL + "?access_key=%s&base=%s&symbols=%s",
+                .url(String.format(BASE_URL + "%s/pair/%s/%s",
                         System.getenv("CURRENCY_API_KEY"), base, symbol))
                 .build();
 

--- a/src/main/java/interface_adapter/logged_in/LoggedInState.java
+++ b/src/main/java/interface_adapter/logged_in/LoggedInState.java
@@ -12,6 +12,7 @@ public class LoggedInState {
     private String addStockError;
     private Map<String, Double> tickersToAggregatedQuantities;
     private ChartPanel panel = null;
+    private String currentCurrency = "USD";
 
     public LoggedInState(LoggedInState copy) {
         username = copy.username;
@@ -19,6 +20,7 @@ public class LoggedInState {
         addStockError = copy.addStockError;
         tickersToAggregatedQuantities = copy.getTickersToAggregatedQuantities();
         panel = copy.panel;
+        currentCurrency = copy.currentCurrency;
     }
 
     // Because of the previous copy constructor, the default constructor must be explicit.
@@ -71,5 +73,13 @@ public class LoggedInState {
 
     public void setPanel(ChartPanel panel) {
         this.panel = panel;
+    }
+
+    public String getCurrentCurrency() {
+        return currentCurrency;
+    }
+
+    public void setCurrentCurrency(String currentCurrency) {
+        this.currentCurrency = currentCurrency;
     }
 }

--- a/src/main/java/interface_adapter/logged_in/add_stock/AddStockPresenter.java
+++ b/src/main/java/interface_adapter/logged_in/add_stock/AddStockPresenter.java
@@ -19,6 +19,7 @@ public class AddStockPresenter implements AddStockOutputBoundary {
         loggedInState.setNetProfit(addStockOutputData.getNewStockProfitToDate());
         loggedInState.setTickersToAggregatedQuantities(addStockOutputData.getTickersToQuantities());
         loggedInState.setAddStockError(null);
+        loggedInState.setCurrentCurrency("USD");
         loggedInViewModel.firePropertyChanged();
     }
 

--- a/src/main/java/interface_adapter/logged_in/currency_conversion/CurrencyController.java
+++ b/src/main/java/interface_adapter/logged_in/currency_conversion/CurrencyController.java
@@ -1,0 +1,4 @@
+package interface_adapter.logged_in.currency_conversion;
+
+public class CurrencyController {
+}

--- a/src/main/java/interface_adapter/logged_in/currency_conversion/CurrencyController.java
+++ b/src/main/java/interface_adapter/logged_in/currency_conversion/CurrencyController.java
@@ -1,4 +1,19 @@
 package interface_adapter.logged_in.currency_conversion;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import use_case.currency_conversion.CurrencyInputBoundary;
+import use_case.currency_conversion.CurrencyInputData;
+
 public class CurrencyController {
+    final CurrencyInputBoundary currencyUseCaseInteractor;
+
+
+    public CurrencyController(CurrencyInputBoundary currencyUseCaseInteractor) {
+        this.currencyUseCaseInteractor = currencyUseCaseInteractor;
+    }
+
+    public void execute(String currencyFrom, String currencyTo) throws JsonProcessingException {
+        CurrencyInputData currencyInputData = new CurrencyInputData(currencyFrom, currencyTo);
+        currencyUseCaseInteractor.execute(currencyInputData);
+    }
 }

--- a/src/main/java/interface_adapter/logged_in/currency_conversion/CurrencyPresenter.java
+++ b/src/main/java/interface_adapter/logged_in/currency_conversion/CurrencyPresenter.java
@@ -23,7 +23,7 @@ public class CurrencyPresenter implements CurrencyOutputBoundary {
     public void prepareSuccessView(CurrencyOutputData data) {
         LoggedInState loggedInState = loggedInViewModel.getState();
         loggedInState.setNetProfit(round(Double.valueOf(loggedInState.getNetProfit()) * data.getExchangeRate(), 2));
-        loggedInState.setCurrentCurrency(data.getNewCurrency());
+        loggedInState.setCurrentCurrency(data.getNewCurrency().toUpperCase());
         loggedInViewModel.firePropertyChanged();
     }
 

--- a/src/main/java/interface_adapter/logged_in/currency_conversion/CurrencyPresenter.java
+++ b/src/main/java/interface_adapter/logged_in/currency_conversion/CurrencyPresenter.java
@@ -1,20 +1,29 @@
 package interface_adapter.logged_in.currency_conversion;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import interface_adapter.logged_in.LoggedInState;
+import interface_adapter.logged_in.LoggedInViewModel;
 import use_case.currency_conversion.CurrencyInputBoundary;
 import use_case.currency_conversion.CurrencyInputData;
+import use_case.currency_conversion.CurrencyOutputBoundary;
+import use_case.currency_conversion.CurrencyOutputData;
 import use_case.show.ShowInputData;
 
-public class CurrencyPresenter {
-    final CurrencyInputBoundary currencyUseCaseInteractor;
+public class CurrencyPresenter implements CurrencyOutputBoundary {
+    private final LoggedInViewModel loggedInViewModel;
 
-
-    public CurrencyPresenter(CurrencyInputBoundary currencyUseCaseInteractor) {
-        this.currencyUseCaseInteractor = currencyUseCaseInteractor;
+    public CurrencyPresenter(LoggedInViewModel loggedInViewModel) {
+        this.loggedInViewModel = loggedInViewModel;
     }
 
-    public void execute(String currencyFrom, String currencyTo) throws JsonProcessingException {
-        CurrencyInputData currencyInputData = new CurrencyInputData(currencyFrom, currencyTo);
-        currencyUseCaseInteractor.execute(currencyInputData);
+    @Override
+    public void prepareSuccessView(CurrencyOutputData data) {
+        LoggedInState loggedInState = loggedInViewModel.getState();
+        loggedInState.setNetProfit(Double.valueOf(loggedInState.getNetProfit()) * data.getExchangeRate());
+    }
+
+    @Override
+    public void prepareFailView(String error) {
+
     }
 }

--- a/src/main/java/interface_adapter/logged_in/currency_conversion/CurrencyPresenter.java
+++ b/src/main/java/interface_adapter/logged_in/currency_conversion/CurrencyPresenter.java
@@ -1,0 +1,20 @@
+package interface_adapter.logged_in.currency_conversion;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import use_case.currency_conversion.CurrencyInputBoundary;
+import use_case.currency_conversion.CurrencyInputData;
+import use_case.show.ShowInputData;
+
+public class CurrencyPresenter {
+    final CurrencyInputBoundary currencyUseCaseInteractor;
+
+
+    public CurrencyPresenter(CurrencyInputBoundary currencyUseCaseInteractor) {
+        this.currencyUseCaseInteractor = currencyUseCaseInteractor;
+    }
+
+    public void execute(String currencyFrom, String currencyTo) throws JsonProcessingException {
+        CurrencyInputData currencyInputData = new CurrencyInputData(currencyFrom, currencyTo);
+        currencyUseCaseInteractor.execute(currencyInputData);
+    }
+}

--- a/src/main/java/interface_adapter/logged_in/currency_conversion/CurrencyPresenter.java
+++ b/src/main/java/interface_adapter/logged_in/currency_conversion/CurrencyPresenter.java
@@ -20,6 +20,8 @@ public class CurrencyPresenter implements CurrencyOutputBoundary {
     public void prepareSuccessView(CurrencyOutputData data) {
         LoggedInState loggedInState = loggedInViewModel.getState();
         loggedInState.setNetProfit(Double.valueOf(loggedInState.getNetProfit()) * data.getExchangeRate());
+        loggedInState.setCurrentCurrency(data.getNewCurrency());
+        loggedInViewModel.firePropertyChanged();
     }
 
     @Override

--- a/src/main/java/interface_adapter/logged_in/currency_conversion/CurrencyPresenter.java
+++ b/src/main/java/interface_adapter/logged_in/currency_conversion/CurrencyPresenter.java
@@ -9,6 +9,9 @@ import use_case.currency_conversion.CurrencyOutputBoundary;
 import use_case.currency_conversion.CurrencyOutputData;
 import use_case.show.ShowInputData;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
 public class CurrencyPresenter implements CurrencyOutputBoundary {
     private final LoggedInViewModel loggedInViewModel;
 
@@ -19,7 +22,7 @@ public class CurrencyPresenter implements CurrencyOutputBoundary {
     @Override
     public void prepareSuccessView(CurrencyOutputData data) {
         LoggedInState loggedInState = loggedInViewModel.getState();
-        loggedInState.setNetProfit(Double.valueOf(loggedInState.getNetProfit()) * data.getExchangeRate());
+        loggedInState.setNetProfit(round(Double.valueOf(loggedInState.getNetProfit()) * data.getExchangeRate(), 2));
         loggedInState.setCurrentCurrency(data.getNewCurrency());
         loggedInViewModel.firePropertyChanged();
     }
@@ -27,5 +30,15 @@ public class CurrencyPresenter implements CurrencyOutputBoundary {
     @Override
     public void prepareFailView(String error) {
 
+    }
+
+    private double round(double value, int places) {
+        if (places < 0) {
+            throw new IllegalArgumentException();
+        }
+
+        BigDecimal bd = BigDecimal.valueOf(value);
+        bd = bd.setScale(places, RoundingMode.HALF_UP);
+        return bd.doubleValue();
     }
 }

--- a/src/main/java/interface_adapter/login/LoginPresenter.java
+++ b/src/main/java/interface_adapter/login/LoginPresenter.java
@@ -39,6 +39,7 @@ public class LoginPresenter implements LoginOutputBoundary {
         loggedInState.setUserID(response.getUserID());
         loggedInState.setNetProfit(response.getNetProfit());
         loggedInState.setTickersToAggregatedQuantities(response.getTickersToQuantities());
+        loggedInState.setCurrentCurrency("USD");
 
         this.loggedInViewModel.setState(loggedInState);
         this.loggedInViewModel.setLoggedInUser(response.getUsername());

--- a/src/main/java/use_case/currency_conversion/CurrencyDataAccessInterface.java
+++ b/src/main/java/use_case/currency_conversion/CurrencyDataAccessInterface.java
@@ -1,0 +1,11 @@
+package use_case.currency_conversion;
+
+import entity.AVTimeSeriesDailyResponse;
+import org.json.JSONObject;
+
+import java.io.IOException;
+
+public interface CurrencyDataAccessInterface {
+
+    JSONObject getCurrencyInfo(String base, String symbol);
+}

--- a/src/main/java/use_case/currency_conversion/CurrencyInputBoundary.java
+++ b/src/main/java/use_case/currency_conversion/CurrencyInputBoundary.java
@@ -1,0 +1,8 @@
+package use_case.currency_conversion;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+public interface CurrencyInputBoundary {
+    void execute(CurrencyInputData currencyInputData) throws JsonProcessingException;
+
+}

--- a/src/main/java/use_case/currency_conversion/CurrencyInputData.java
+++ b/src/main/java/use_case/currency_conversion/CurrencyInputData.java
@@ -1,0 +1,19 @@
+package use_case.currency_conversion;
+
+public class CurrencyInputData {
+    public String getCurrencyFrom() {
+        return currencyFrom;
+    }
+
+    public String getCurrencyTo() {
+        return currencyTo;
+    }
+
+    final private String currencyFrom;
+    final private String currencyTo;
+
+    public CurrencyInputData(String currencyFrom, String currencyTo) {
+        this.currencyFrom = currencyFrom;
+        this.currencyTo = currencyTo;
+    }
+}

--- a/src/main/java/use_case/currency_conversion/CurrencyInteractor.java
+++ b/src/main/java/use_case/currency_conversion/CurrencyInteractor.java
@@ -1,0 +1,47 @@
+package use_case.currency_conversion;
+
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import entity.Portfolio;
+import entity.Stock;
+import org.jfree.chart.ChartFactory;
+import org.jfree.chart.ChartPanel;
+import org.jfree.chart.JFreeChart;
+import org.jfree.chart.plot.XYPlot;
+import org.jfree.data.time.Day;
+import org.jfree.data.time.TimeSeries;
+import org.jfree.data.time.TimeSeriesCollection;
+import org.json.JSONObject;
+
+import java.awt.*;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+public class CurrencyInteractor implements CurrencyInputBoundary {
+    final CurrencyDataAccessInterface currencyDataAccessObject;
+    final CurrencyOutputBoundary currencyPresenter;
+
+    public CurrencyInteractor(CurrencyDataAccessInterface currencyDataAccessObject, CurrencyOutputBoundary currencyPresenter) {
+        this.currencyDataAccessObject = currencyDataAccessObject;
+        this.currencyPresenter = currencyPresenter;
+    }
+
+    @Override
+    public void execute(CurrencyInputData currencyInputData) throws JsonProcessingException {
+        JSONObject rawCurrencyInfo = currencyDataAccessObject.getCurrencyInfo(currencyInputData.getCurrencyFrom(), currencyInputData.getCurrencyTo());
+        HashMap<String, String> processedStockInfo = jsonToHashMap(rawCurrencyInfo);
+        CurrencyOutputData currencyOutputData = new CurrencyOutputData(Double.valueOf(processedStockInfo.get(currencyInputData.getCurrencyTo())));
+        currencyPresenter.prepareSuccessView(currencyOutputData);
+    }
+
+    public HashMap<String, String> jsonToHashMap(JSONObject rawCurrencyInfo) throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+        HashMap rawMap = mapper.readValue(rawCurrencyInfo.toString(), HashMap.class);
+        return (HashMap<String, String>) rawMap.get("rates");
+
+    }
+}

--- a/src/main/java/use_case/currency_conversion/CurrencyInteractor.java
+++ b/src/main/java/use_case/currency_conversion/CurrencyInteractor.java
@@ -3,22 +3,9 @@ package use_case.currency_conversion;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import entity.Portfolio;
-import entity.Stock;
-import org.jfree.chart.ChartFactory;
-import org.jfree.chart.ChartPanel;
-import org.jfree.chart.JFreeChart;
-import org.jfree.chart.plot.XYPlot;
-import org.jfree.data.time.Day;
-import org.jfree.data.time.TimeSeries;
-import org.jfree.data.time.TimeSeriesCollection;
 import org.json.JSONObject;
 
-import java.awt.*;
-import java.time.LocalDateTime;
 import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 
 public class CurrencyInteractor implements CurrencyInputBoundary {
@@ -33,15 +20,13 @@ public class CurrencyInteractor implements CurrencyInputBoundary {
     @Override
     public void execute(CurrencyInputData currencyInputData) throws JsonProcessingException {
         JSONObject rawCurrencyInfo = currencyDataAccessObject.getCurrencyInfo(currencyInputData.getCurrencyFrom(), currencyInputData.getCurrencyTo());
-        HashMap<String, String> processedStockInfo = jsonToHashMap(rawCurrencyInfo);
-        CurrencyOutputData currencyOutputData = new CurrencyOutputData(Double.valueOf(processedStockInfo.get(currencyInputData.getCurrencyTo())));
+        HashMap processedStockInfo = jsonToHashMap(rawCurrencyInfo);
+        CurrencyOutputData currencyOutputData = new CurrencyOutputData((Double) processedStockInfo.get("conversion_rate"), currencyInputData.getCurrencyTo());
         currencyPresenter.prepareSuccessView(currencyOutputData);
     }
 
-    public HashMap<String, String> jsonToHashMap(JSONObject rawCurrencyInfo) throws JsonProcessingException {
+    public HashMap jsonToHashMap(JSONObject rawCurrencyInfo) throws JsonProcessingException {
         ObjectMapper mapper = new ObjectMapper();
-        HashMap rawMap = mapper.readValue(rawCurrencyInfo.toString(), HashMap.class);
-        return (HashMap<String, String>) rawMap.get("rates");
-
+        return mapper.readValue(rawCurrencyInfo.toString(), HashMap.class);
     }
 }

--- a/src/main/java/use_case/currency_conversion/CurrencyOutputBoundary.java
+++ b/src/main/java/use_case/currency_conversion/CurrencyOutputBoundary.java
@@ -1,0 +1,7 @@
+package use_case.currency_conversion;
+
+public interface CurrencyOutputBoundary {
+    void prepareSuccessView(CurrencyOutputData data);
+
+    void prepareFailView(String error);
+}

--- a/src/main/java/use_case/currency_conversion/CurrencyOutputData.java
+++ b/src/main/java/use_case/currency_conversion/CurrencyOutputData.java
@@ -1,12 +1,17 @@
 package use_case.currency_conversion;
 
-import org.jfree.chart.ChartPanel;
-
 public class CurrencyOutputData {
     private final double exchangeRate;
 
-    public CurrencyOutputData(double exchangeRate) {
+    public String getNewCurrency() {
+        return newCurrency;
+    }
+
+    private final String newCurrency;
+
+    public CurrencyOutputData(double exchangeRate, String newCurrency) {
         this.exchangeRate = exchangeRate;
+        this.newCurrency = newCurrency;
     }
 
     public double getExchangeRate() {

--- a/src/main/java/use_case/currency_conversion/CurrencyOutputData.java
+++ b/src/main/java/use_case/currency_conversion/CurrencyOutputData.java
@@ -1,0 +1,17 @@
+package use_case.currency_conversion;
+
+import org.jfree.chart.ChartPanel;
+
+public class CurrencyOutputData {
+    private final double exchangeRate;
+
+    public CurrencyOutputData(double exchangeRate) {
+        this.exchangeRate = exchangeRate;
+    }
+
+    public double getExchangeRate() {
+        return exchangeRate;
+    }
+
+
+}

--- a/src/main/java/use_case/show/ShowInteractor.java
+++ b/src/main/java/use_case/show/ShowInteractor.java
@@ -70,7 +70,6 @@ public class ShowInteractor implements ShowInputBoundary {
                             dateToNetWorth.getOrDefault(dateStringWithoutTime, 0.0));
                 }
             }
-            ;
         }
 
         for (Map.Entry<String, Double> entry : dateToNetWorth.entrySet()) {

--- a/src/main/java/view/LoggedInView.java
+++ b/src/main/java/view/LoggedInView.java
@@ -49,6 +49,7 @@ public class LoggedInView extends JPanel implements ActionListener, PropertyChan
 
     JButton editStock;
     JButton showButton;
+    JButton currencyButton;
     JPanel stocksScrollableList;
     JPanel plot;
 
@@ -98,6 +99,9 @@ public class LoggedInView extends JPanel implements ActionListener, PropertyChan
 
         showButton = new JButton("Update Plot and Net Profit");
         showButton.addActionListener(this);
+
+        currencyButton = new JButton("Change Net Profit Currency");
+        currencyButton.addActionListener(this);
 
         this.setLayout(new GridBagLayout()); // Use GridBagLayout
 
@@ -158,10 +162,16 @@ public class LoggedInView extends JPanel implements ActionListener, PropertyChan
 
         // Sets the coordinates for the Edit Stock button
         gbc.gridx = 7;
-        gbc.gridwidth = 4;
         gbc.anchor = GridBagConstraints.EAST;
         // Creates the Edit Stock button
         this.add(editStock, gbc);
+
+        // Sets the coordinates for the Convert Currency button
+        gbc.gridx = 8;
+        gbc.anchor = GridBagConstraints.EAST;
+        // Creates the Convert Currency Button
+        this.add(currencyButton, gbc);
+
 
         gbc.gridx = 0;
         gbc.gridy = 1;
@@ -174,7 +184,7 @@ public class LoggedInView extends JPanel implements ActionListener, PropertyChan
         gbc.gridwidth = 6;
         gbc.gridheight = 2;
         this.add(plot, gbc);
-        gbc.gridx = 6;
+        gbc.gridx = 8;
         gbc.gridy = 2;
         gbc.gridheight = 5;
         gbc.anchor = GridBagConstraints.NORTH;
@@ -370,7 +380,7 @@ public class LoggedInView extends JPanel implements ActionListener, PropertyChan
             this.remove(stocksScrollableList);
             stocksScrollableList = new ScrollableStockList(state.getTickersToAggregatedQuantities());
 
-            gbc.gridx = 6;
+            gbc.gridx = 8;
             gbc.gridy = 2;
             gbc.gridheight = 5;
             gbc.anchor = GridBagConstraints.NORTH;

--- a/src/main/java/view/LoggedInView.java
+++ b/src/main/java/view/LoggedInView.java
@@ -168,13 +168,13 @@ public class LoggedInView extends JPanel implements ActionListener, PropertyChan
 
         // Sets the coordinates for the Edit Stock button
         gbc.gridx = 7;
-        gbc.anchor = GridBagConstraints.EAST;
+        gbc.anchor = GridBagConstraints.NORTH;
         // Creates the Edit Stock button
         this.add(editStock, gbc);
 
         // Sets the coordinates for the Convert Currency button
         gbc.gridx = 8;
-        gbc.anchor = GridBagConstraints.EAST;
+        gbc.anchor = GridBagConstraints.NORTH;
         // Creates the Convert Currency Button
         this.add(currencyButton, gbc);
 
@@ -242,6 +242,13 @@ public class LoggedInView extends JPanel implements ActionListener, PropertyChan
                 }
 
                 addStockController.execute(ticker, date, amountStr, loggedInViewModel.getState().getUserID());
+
+                // Must convert to current currency, as netProfit calculated by add use case uses USD
+                try {
+                    currencyController.execute("USD", loggedInViewModel.getState().getCurrentCurrency());
+                } catch (JsonProcessingException e) {
+                    throw new RuntimeException(e);
+                }
             }
 
 

--- a/src/main/java/view/LoggedInView.java
+++ b/src/main/java/view/LoggedInView.java
@@ -414,7 +414,7 @@ public class LoggedInView extends JPanel implements ActionListener, PropertyChan
         Set<String> validSymbols = new HashSet<>(Arrays.asList("AED", "AFN", "ALL", "AMD", "ANG", "AOA", "ARS", "AUD", "AWG", "AZN", "BAM", "BBD", "BDT", "BGN", "BHD", "BIF", "BMD", "BND", "BOB", "BRL", "BSD", "BTN", "BWP", "BYN", "BZD", "CAD", "CDF", "CHF", "CLP", "CNY", "COP", "CRC", "CUP", "CVE", "CZK", "DJF", "DKK", "DOP", "DZD", "EGP", "ERN", "ETB", "EUR", "FJD", "FKP", "FOK", "GBP", "GEL", "GGP", "GHS", "GIP", "GMD", "GNF", "GTQ", "GYD", "HKD", "HNL", "HRK", "HTG", "HUF", "IDR", "ILS", "IMP", "INR", "IQD", "IRR", "ISK", "JEP", "JMD", "JOD", "JPY", "KES", "KGS", "KHR", "KID", "KMF", "KRW", "KWD", "KYD", "KZT", "LAK", "LBP", "LKR", "LRD", "LSL", "LYD", "MAD", "MDL", "MGA", "MKD", "MMK", "MNT", "MOP", "MRU", "MUR", "MVR", "MWK", "MXN", "MYR", "MZN", "NAD", "NGN", "NIO", "NOK", "NPR", "NZD", "OMR", "PAB", "PEN", "PGK", "PHP", "PKR", "PLN", "PYG", "QAR", "RON", "RSD", "RUB", "RWF", "SAR", "SBD", "SCR", "SDG", "SEK", "SGD", "SHP", "SLE", "SOS", "SRD", "SSP", "STN", "SYP", "SZL", "THB", "TJS", "TMT", "TND", "TOP", "TRY", "TTD", "TVD", "TWD", "TZS", "UAH", "UGX", "USD", "UYU", "UZS", "VES", "VND", "VUV", "WST", "XAF", "XCD", "XDR", "XOF", "XPF", "YER", "ZAR", "ZMW", "ZWL"
         ));
         if (!symbol.isEmpty()) {
-            if (!validSymbols.contains(symbol)) {
+            if (!validSymbols.contains(symbol.toUpperCase())) {
                 JOptionPane.showMessageDialog(this, "Please enter a valid 3-letter currency code.");
             }
             else {return;}


### PR DESCRIPTION
![image](https://github.com/wkukka1/PortfolioTracker/assets/105831093/f1258f8b-040b-47b9-a6b2-c37106b52d61)
![image](https://github.com/wkukka1/PortfolioTracker/assets/105831093/8b3abbf4-47e8-4859-ab9f-18936c7c39e0)

The currency conversion use case deals with changing the currency of the net profit displayed on the logged-in screen. Click on "Change Net Profit Currency" on the logged-in screen to invoke the use case. Note that this use case only changes the DISPLAYED value of the net profit; net profit data saved in the backend are still in USD. It uses [ExchangeRate-API](https://www.exchangerate-api.com/docs/pair-conversion-requests)'s pair-conversion endpoint. When running, make sure to add the API key as an environment variable in your IDE.